### PR TITLE
arrumando erro de digitação para receber "tipo"

### DIFF
--- a/application/controllers/Professor.php
+++ b/application/controllers/Professor.php
@@ -33,7 +33,7 @@ class Professor extends CI_Controller {
     public function setCodigo($codigoFront){$this->codigo=$codigoFront;}
     public function setNome($nomeFront){$this->nome=$nomeFront;}
     public function setCpf($cpfFront){$this->cpf=$cpfFront;}
-    public function setTipo($tipoFront){$this->ctipo=$tipoFront;}
+    public function setTipo($tipoFront){$this->tipo=$tipoFront;}
     public function setEstatus($estatusFront){$this->estatus=$estatusFront;}
 
     public function inserir(){


### PR DESCRIPTION
O valor tipo não estava sendo recebido por conta de um erro de digitação.

Outro teste feito foi novamente do CPF, sem alterações do código, e ele aceitou os CPFs que foram testados anteriormente então não foi necessário correções